### PR TITLE
Fix savePrevious initialization

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -21,20 +21,12 @@ import("baseline-browser-mapping").then((bbm) => {
 
   const fs = require("node:fs");
 
-  let incomingConfig = packageJSON.bl2bl ? packageJSON.bl2bl : {};
+  let incomingConfig = packageJSON.bl2bl ?? {};
   const bl2blConfig = {
-    baselineThreshold: incomingConfig.baselineThreshold
-      ? incomingConfig.baselineThreshold
-      : "widely available",
-    useBrowserslistrc: incomingConfig.useBrowserslistrc
-      ? incomingConfig.useBrowserslistrc
-      : false,
-    downstreamBrowsers: incomingConfig.downstreamBrowsers
-      ? incomingConfig.downstreamBrowsers
-      : false,
-    savePrevious: incomingConfig.savePrevious
-      ? incomingConfig.savePrevious
-      : true,
+    baselineThreshold: incomingConfig.baselineThreshold ?? "widely available",
+    useBrowserslistrc: incomingConfig.useBrowserslistrc ?? false,
+    downstreamBrowsers: incomingConfig.downstreamBrowsers ?? false,
+    savePrevious: incomingConfig.savePrevious ?? true,
   };
 
   packageJSON.bl2bl = bl2blConfig;


### PR DESCRIPTION
Fixes #1

Uses nullish coalescing to initialize the bl2blConfig options, rather than ternaries. The issue was that when `savePrevious` was false, it would fail the ternary condition and immediately get set to true.